### PR TITLE
5.1 VBIN Reading Bugfixes

### DIFF
--- a/VBINtoSTL.cpp
+++ b/VBINtoSTL.cpp
@@ -45,13 +45,17 @@ int VBIN::readData(){
     //gets all scene nodes in the file, populates their PositionArrays and IndexArrays, and gets modifications
     currentLocation = 0;
     base.file = this;
+    base.name = "vbinbase";
     //base.getSceneNodeTree(0, parent->fileData.dataBytes.length(), 0);
     if(getSceneNodeTree()){
         qDebug() << Q_FUNC_INFO << "Error while reading scene node tree";
         return 1;
     }
-    //qDebug() << Q_FUNC_INFO << "section list size" << base.sectionList.size() << "mesh list size" << base.meshList.size();
-    //base.printInfo(0);
+    base.printInfo(0);
+    std::vector<Modifications> addedMods;
+    base.modifyPosArrays(addedMods);
+
+    qDebug() << Q_FUNC_INFO << "section list size" << base.sectionList.size() << "mesh list size" << base.meshList.size();
 
     //qDebug() << Q_FUNC_INFO << "section list length" << base.sectionList.size() << "typelist length" << base.sectionTypes.size();
 
@@ -89,12 +93,13 @@ void FileSection::printInfo(int depth){
     //qDebug() << Q_FUNC_INFO << name << "section list size" << sectionList.size() << "mesh list size" << meshList.size();
     //qDebug() << Q_FUNC_INFO << "file name" << file->fileName;
     if(depth > 0){
-        //qDebug() << Q_FUNC_INFO << "depth" << depth << "section name" << name << "with parent" << parent->name;
+        qDebug() << Q_FUNC_INFO << "depth" << depth << "section name" << name << "with parent" << parent->name;
     }
     for(int i = 0; i < sectionList.size(); i++){
         sectionList[i]->printInfo(depth+1);
     }
     for(int i = 0; i < meshList.size(); i++){
+        //qDebug() << Q_FUNC_INFO << meshList[i]->name << "position list has" << meshList[i]->vertexSet.positionArray.positionList.size();
         meshList[i]->printInfo(depth+1);
     }
 }
@@ -103,46 +108,18 @@ void FileSection::modifyPosArrays(std::vector<Modifications> addedMods){
     QMatrix3x3 rotMatrix;
     Mesh modifyMesh;
     SceneNode modifyNode;
-    //QMatrix4x4 rotMatrix4;
-    //QVector4D expandVector;
-    //stackedMods.rotation = mods.rotation * addedMods.rotation;
-    //stackedMods.scale = mods.scale * addedMods.scale;
-    //qDebug() << Q_FUNC_INFO << "Getting modifications for " << name << " current scale: " << mods.scale << "passed mods:" << addedMods.scale << "new scale:" << stackedMods.scale;
-    addedMods.push_back(mods);
-
-    for(int i = 0; i < sectionList.size(); i++){
-        if(sectionTypes[i] == "Mesh"){
-            sectionList[i]->modify(addedMods);
-//            if(sectionList[i].sectionList.size() > 0){
-//                sectionList[i].modifyPosArrays(addedMods);
-//            }
-//            for (int j = 0; j < sectionList[i].posArray.vertexCount; ++j) {
-//                for(int k = 0; k < addedMods.size(); k++){
-//                    //rotMatrix = std::get<Mesh>(sectionList[i]).mods.rotation.toRotationMatrix();
-//                    //expandVector = QVector4D(std::get<Mesh>(sectionList[i]).posArray.positionList[i]);
-//                    //rotMatrix4 = QMatrix4x4(rotMatrix);
-
-//                    sectionList[i].posArray.positionList[j] = sectionList[i].posArray.positionList[j] * addedMods[k].scale;
-//                    sectionList[i].posArray.positionList[j] = sectionList[i].posArray.positionList[j] + addedMods[k].offset;
-//                    //std::get<Mesh>(sectionList[i]).posArray.positionList[j] = file->parent->binChanger.forcedRotate(rotMatrix, addedMods[k].offset, std::get<Mesh>(sectionList[i]).posArray.positionList[j]);
-//                    //std::get<Mesh>(sectionList[i]).posArray.positionList[j] = QVector3D(expandVector*rotMatrix4);
-//                    //std::get<Mesh>(sectionList[i]).posArray.positionList[j] = mods.rotation.rotatedVector(std::get<Mesh>(sectionList[i]).posArray.positionList[j]);
-//                    //std::get<Mesh>(sectionList[i]).posArray.positionList[j] = addedMods[k].rotation * std::get<Mesh>(sectionList[i]).posArray.positionList[j];
-//                    //std::get<Mesh>(sectionList[i]).posArray.positionList[j] = mods.rotation * std::get<Mesh>(sectionList[i]).posArray.positionList[j];
-//                }
-//                sectionList[i].posArray.positionList[j] = sectionList[i].posArray.positionList[j] * sectionList[i].mods.scale;
-//                sectionList[i].posArray.positionList[j] = sectionList[i].posArray.positionList[j] + sectionList[i].mods.offset;
-//                //std::get<Mesh>(sectionList[i]).posArray.positionList[j] = std::get<Mesh>(sectionList[i]).mods.rotation * std::get<Mesh>(sectionList[i]).posArray.positionList[j];
-//                //std::get<Mesh>(sectionList[i]).posArray.positionList[j] = std::get<Mesh>(sectionList[i]).mods.rotation.rotatedVector(std::get<Mesh>(sectionList[i]).posArray.positionList[j]);
-//            }
-
-        } else {
-            if(sectionList[i]->sectionList.size() > 0){
-                sectionList[i]->modifyPosArrays(addedMods);
-            }
-        }
+    if(name != "vbinbase"){
+        addedMods.push_back(mods);
+        //qDebug() << Q_FUNC_INFO << "Getting modifications for " << name << " current scale: " << mods.scale << "passed mods" << addedMods[addedMods.size()-1].scale;
     }
 
+    for (int i = 0; i < int(meshList.size()); i++) {
+        meshList[i]->modifyPosArrays(addedMods);
+        meshList[i]->modify(addedMods);
+    }
+    for(int i = 0; i < int(sectionList.size()); i++){
+        sectionList[i]->modifyPosArrays(addedMods);
+    }
     return;
 }
 
@@ -197,10 +174,49 @@ void VBIN::readBoundingVolume(){
     }
 }
 
+void FileSection::readModifications(){
+    int offsets = 0;
+    float x_value = 0;
+    float y_value = 0;
+    float z_value = 0;
+    float m_value = 0;
+    //offset properties
+    offsets = file->parent->fileData.readInt(1);
+    if (!(offsets & 1)) {
+        //position offset
+        x_value = file->parent->fileData.readFloat();
+        y_value = file->parent->fileData.readFloat();
+        z_value = file->parent->fileData.readFloat();
+        mods.offset = QVector3D(x_value, y_value, z_value);
+    } else {
+        mods.offset = QVector3D(0,0,0);
+    }
+    if (!(offsets & 2)) {
+        //rotation offset
+        x_value = file->parent->fileData.readFloat();
+        y_value = file->parent->fileData.readFloat();
+        z_value = file->parent->fileData.readFloat();
+        m_value = file->parent->fileData.readFloat();
+        mods.rotation = QQuaternion(m_value, x_value, y_value, z_value);
+    } else {
+        mods.rotation = QQuaternion(1,0,0,0);
+    }
+    if (!(offsets & 4)) {
+        //scale offset
+        m_value = file->parent->fileData.readFloat();
+        mods.scale = m_value;
+    } else {
+        mods.scale = 1;
+    }
+}
+
 void VBIN::readModifications(){
+    //This only exists for the AnimationPrototype section
+    //eventually AnimationPrototype needs to be a filesection like the rest
     int offsets = 0;
     //offset properties
     offsets = parent->fileData.readInt(1);
+    qDebug() << Q_FUNC_INFO << "offsets read as" << offsets;
     if (!(offsets & 1)) {
         //position offset
         parent->fileData.currentPosition += 12;
@@ -233,93 +249,23 @@ int VBIN::getSceneNodeTree(){
     FileSection* currentBranch;
     FileSection* possibleBranch;
 
-    signature = parent->fileData.getSignature();
+    //signature = parent->fileData.getSignature();
 
-    sectionNameLength = parent->fileData.readInt();
-    sectionName = parent->fileData.readHex(sectionNameLength);
+    //sectionNameLength = parent->fileData.readInt();
+    //sectionName = parent->fileData.readHex(sectionNameLength);
     //qDebug() << Q_FUNC_INFO << "name length " << sectionNameLength << " read as " << sectionName;
 
-    sectionLength = parent->fileData.readInt();
-    base.sectionLength = sectionLength;
-    base.sectionEnd = parent->fileData.currentPosition -4 + sectionLength;
-    qDebug() << Q_FUNC_INFO << "end of tree excpeted at" << base.sectionEnd;
+    //sectionLength = parent->fileData.readInt();
+    //qDebug() << Q_FUNC_INFO << "end of tree excpeted at" << base.sectionEnd;
+    base.sectionLength = 0;
     base.fileLocation = 0;
     currentBranch = &base;
+    possibleBranch = &base;
 
     while(1){
-        if(signature == "~anAnimationSourceSet"){
-            qDebug() << Q_FUNC_INFO << "End of tree located - leaving at Animation Data";
-            break;
-        }
-
-        if(signature == "~Mesh"){
-            Mesh *meshSection = new Mesh();
-            meshSection->file = this; //file will need to be reassigned later as the current VBIN object is temporary
-            meshSection->parent = currentBranch;
-            meshSection->fileLocation = parent->fileData.currentPosition-4;
-            meshSection->sectionLength = sectionLength;
-            meshSection->sectionEnd = meshSection->fileLocation + sectionLength;
-            meshSection->name = sectionName;
-
-            if (sectionName == "CollisionMesh") {
-                parent->messageError("It looks like you're trying to read a Collision Mesh. "
-                                     "These models have weird stuff going on and are not currently compatible with this program.");
-                return 1;
-            }
-
-            if(meshSection->readMesh()){
-                qDebug() << "Error while reading mesh";
-                return 1;
-            }
-
-            currentBranch->meshList.push_back(meshSection);
-            possibleBranch = meshSection;
-            //qDebug() << Q_FUNC_INFO << "name " << meshSection->name << "with parent" << meshSection->parent->name;
-        }
-
-        if(signature == "~SceneNode"){
-            SceneNode *sceneSection = new SceneNode();
-            sceneSection->file = this;
-            sceneSection->parent = currentBranch;
-            sceneSection->fileLocation = parent->fileData.currentPosition-4;
-            sceneSection->sectionLength = sectionLength;
-            sceneSection->sectionEnd = sceneSection->fileLocation + sectionLength;
-            sceneSection->name = sectionName;
-            currentBranch->sectionList.push_back(sceneSection);
-            possibleBranch = sceneSection;
-            //qDebug() << Q_FUNC_INFO << "name " << sceneSection->name << "with parent" << sceneSection->parent->name;
-        }
-
-        if(signature == "~anAnimationPrototype"){
-            readAnimationPrototype();
-        }
-
-        unknown4Byte1 = parent->fileData.readInt(); //looks like this value is always 4? I haven't found an exception to this
-            //unfortunately means it's really hard to figure out what this is for.
-        qDebug() << Q_FUNC_INFO << "section name" << sectionName << "with unknown value" << unknown4Byte1;
-
-        readModifications();
-
-        unknown4Byte2 = parent->fileData.readInt();
-        parent->fileData.currentPosition += 8;
-        unknown4Byte3 = parent->fileData.readInt(); //this should take us to the end
-
-        signature = parent->fileData.getSignature();
-
-        if(signature == "~BoundingVolume"){
-            readBoundingVolume();
-        }
-        qDebug() << Q_FUNC_INFO << "Expected end of section at location: " << parent->fileData.currentPosition;
-
-        loopBreaker++;
-        if (loopBreaker > 100 or parent->fileData.currentPosition > base.sectionEnd){
-            parent->messageError("Excessive looping detected or node tree exceeded for file " + fileName);
-            qDebug() << Q_FUNC_INFO << "Excessive looping detected or node tree exceeded.";
-            return 1;
-        }
 
         if (parent->fileData.currentPosition == base.sectionEnd){
-            qDebug() << Q_FUNC_INFO << "File does not have animation data. Exiting now.";
+            qDebug() << Q_FUNC_INFO << "Reached end of tree. Exiting now.";
             return 0;
         }
 
@@ -341,6 +287,117 @@ int VBIN::getSceneNodeTree(){
         //qDebug() << Q_FUNC_INFO << "name length " << sectionNameLength << " read as " << sectionName;
 
         sectionLength = parent->fileData.readInt();
+
+        if (base.sectionLength == 0) {
+            base.sectionLength = sectionLength;
+            base.sectionEnd = parent->fileData.currentPosition -4 + sectionLength;
+        }
+
+        if(signature == "~anAnimationSourceSet"){
+            //qDebug() << Q_FUNC_INFO << "End of tree located - leaving at Animation Data";
+            //break;
+            qDebug() << Q_FUNC_INFO << "Found animation data at " << parent->fileData.currentPosition << "- skipping for now";
+            parent->fileData.currentPosition += sectionLength-4;
+            qDebug() << Q_FUNC_INFO << "position after skip" << parent->fileData.currentPosition;
+            continue;
+        }
+
+        if(signature == "~Mesh"){
+            Mesh *meshSection = new Mesh();
+            meshSection->file = this; //file will need to be reassigned later as the current VBIN object is temporary
+            meshSection->parent = currentBranch;
+            meshSection->fileLocation = parent->fileData.currentPosition-4;
+            meshSection->sectionLength = sectionLength;
+            meshSection->sectionEnd = meshSection->fileLocation + sectionLength;
+            meshSection->name = sectionName;
+
+            if (sectionName == "CollisionMesh") {
+                parent->messageError("It looks like you're trying to read a Collision Mesh. "
+                                     "These models have weird stuff going on and are not currently compatible with this program.");
+                return 1;
+            }
+
+            if(meshSection->readMesh()){
+                qDebug() << "Error while reading mesh";
+                return 1;
+            }
+            unknown4Byte1 = parent->fileData.readInt();
+            meshSection->readModifications();
+            //qDebug() << Q_FUNC_INFO << "mesh offsets: scale" << meshSection->mods.scale << "offset" << meshSection->mods.offset << "rotation" << meshSection->mods.rotation;
+
+            currentBranch->meshList.push_back(meshSection);
+            possibleBranch = meshSection;
+            //qDebug() << Q_FUNC_INFO << "name " << meshSection->name << "with parent" << meshSection->parent->name;
+        }
+
+        if(signature == "~SceneNode"){
+            SceneNode *sceneSection = new SceneNode();
+            sceneSection->file = this;
+            sceneSection->parent = currentBranch;
+            sceneSection->fileLocation = parent->fileData.currentPosition-4;
+            sceneSection->sectionLength = sectionLength;
+            sceneSection->sectionEnd = sceneSection->fileLocation + sectionLength;
+            sceneSection->name = sectionName;
+            unknown4Byte1 = parent->fileData.readInt();
+            sceneSection->readModifications();
+            currentBranch->sectionList.push_back(sceneSection);
+            possibleBranch = sceneSection;
+            //qDebug() << Q_FUNC_INFO << "name " << sceneSection->name << "with parent" << sceneSection->parent->name;
+        }
+
+        if(signature == "~anAnimationPrototype"){
+            readAnimationPrototype();
+            unknown4Byte1 = parent->fileData.readInt();
+            readModifications();
+        }
+
+        //unknown4Byte1 = parent->fileData.readInt(); //looks like this value is always 4? I haven't found an exception to this
+            //unfortunately means it's really hard to figure out what this is for.
+        //qDebug() << Q_FUNC_INFO << "section name" << sectionName << "with unknown value" << unknown4Byte1;
+
+        //readModifications();
+
+        unknown4Byte2 = parent->fileData.readInt();
+        parent->fileData.currentPosition += 8;
+        unknown4Byte3 = parent->fileData.readInt(); //this should take us to the end
+
+        signature = parent->fileData.getSignature();
+
+        if(signature == "~BoundingVolume"){
+            readBoundingVolume();
+        }
+        //qDebug() << Q_FUNC_INFO << "Expected end of section at location: " << parent->fileData.currentPosition;
+
+        loopBreaker++;
+        if (loopBreaker > 100 or parent->fileData.currentPosition > base.sectionEnd){
+            parent->messageError("Excessive looping detected or node tree exceeded for file " + fileName);
+            qDebug() << Q_FUNC_INFO << "Excessive looping detected or node tree exceeded.";
+            return 1;
+        }
+
+        if (parent->fileData.currentPosition == base.sectionEnd){
+            qDebug() << Q_FUNC_INFO << "Reached end of tree. Exiting now.";
+            return 0;
+        }
+
+//        //Checks if we've reached the end of a branch in the scene node tree. If we're at the root of the tree, there's nowhere to go.
+//        if(currentBranch->sectionEnd == parent->fileData.currentPosition && currentBranch->fileLocation !=0){
+//            while(currentBranch->sectionEnd == currentBranch->parent->sectionEnd){
+//                currentBranch = currentBranch->parent;
+//                //qDebug() << Q_FUNC_INFO << "Branch completed, moving back up a layer";
+//            }
+//            currentBranch = currentBranch->parent;
+//        } else if (possibleBranch->sectionEnd != parent->fileData.currentPosition) {
+//            currentBranch = possibleBranch;
+//        }
+
+//        signature = parent->fileData.getSignature();
+
+//        sectionNameLength = parent->fileData.readInt();
+//        sectionName = parent->fileData.readHex(sectionNameLength);
+//        //qDebug() << Q_FUNC_INFO << "name length " << sectionNameLength << " read as " << sectionName;
+
+//        sectionLength = parent->fileData.readInt();
     }
 
     return 0; //read successfully
@@ -360,7 +417,6 @@ void ProgWindow::convertVBINToSTL(){
 void FileSection::writeSectionList(QTextStream &fileOut){
     //for writing to a single file
     for (int i = 0; i < int(meshList.size()); i++) {
-        //qDebug() << Q_FUNC_INFO << "section" << i << "is type:" << sectionTypes[i];
         meshList[i]->file = file;
         meshList[i]->writeData(fileOut);
         meshList[i]->writeSectionList(fileOut);
@@ -385,9 +441,11 @@ void FileSection::writeSectionList(QString path){
             continue;
         }
         QTextStream stream(&stlOut);
+        stream << "solid Default" << Qt::endl;
 
         meshList[i]->file = file;
         meshList[i]->writeData(stream);
+        stream << "endsolid Default" << Qt::endl;
         meshList[i]->writeSectionList(path);
     }
     for(int i = 0; i < int(sectionList.size()); i++){
@@ -400,6 +458,7 @@ void VBIN::outputData(){
 
     std::vector<int> allowedMeshes = {1,2,3};
     std::vector<int> chosenLOD;
+    base.file = this;
 
     if(parent->radioSingle->isChecked()){
         QString fileOut = QFileDialog::getSaveFileName(parent, parent->tr("Select Output STL"), QDir::currentPath() + "/STL/", parent->tr("Model Files (*.stl)"));
@@ -415,19 +474,30 @@ void VBIN::outputData(){
         stream << "solid Default" << Qt::endl;
         qDebug() << Q_FUNC_INFO << "sections:" << base.sectionList.size();
         qDebug() << Q_FUNC_INFO << "meshes:" << base.meshList.size();
-        for (int i = 0; i < int(base.sectionList.size()); i++) {
-            base.sectionList[i]->file = this;
-            qDebug() << Q_FUNC_INFO << "writing mesh" << i << "named" << base.sectionList[i]->name << "with file" << base.sectionList[i]->file->fileName;
-            base.sectionList[i]->writeSectionList(stream);
-        }
+        base.writeSectionList(stream);
+//        for (int i = 0; i < int(base.sectionList.size()); i++) {
+//            base.sectionList[i]->file = this;
+//            qDebug() << Q_FUNC_INFO << "writing node" << i << "named" << base.sectionList[i]->name << "with file" << base.sectionList[i]->file->fileName;
+//            base.sectionList[i]->writeSectionList(stream);
+//        }
+//        for (int i = 0; i < int(base.meshList.size()); i++) {
+//            base.meshList[i]->file = this;
+//            qDebug() << Q_FUNC_INFO << "writing mesh" << i << "named" << base.meshList[i]->name << "with file" << base.meshList[i]->file->fileName;
+//            base.meshList[i]->writeData(stream);
+//            base.meshList[i]->writeSectionList(stream);
+//        }
         stream << "endsolid Default" << Qt::endl;
     } else {
         QString fileOut = QFileDialog::getExistingDirectory(parent, parent->tr("Select Output STL"), QDir::currentPath() + "/STL/", QFileDialog::ShowDirsOnly);
-        for (int i = 0; i < int(base.sectionList.size()); i++) {
-            base.sectionList[i]->file = this;
-            //qDebug() << Q_FUNC_INFO << "section" << i << "is type:" << base.sectionTypes[i];
-            base.sectionList[i]->writeSectionList(fileOut);
-        }
+        base.writeSectionList(fileOut);
+//        for (int i = 0; i < int(base.sectionList.size()); i++) {
+//            base.sectionList[i]->file = this;
+//            base.sectionList[i]->writeSectionList(fileOut);
+//        }
+//        for (int i = 0; i < int(base.meshList.size()); i++) {
+//            base.meshList[i]->file = this;
+//            base.meshList[i]->writeSectionList(fileOut);
+//        }
     }
 
     qDebug() << Q_FUNC_INFO << "Output complete.";

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -58,6 +58,7 @@ ProgWindow::ProgWindow(QWidget *parent)
     geometrySet->parent = this;
     PaletteTable = nullptr;
     ListLevels = nullptr;
+    ListFiles = nullptr;
     radioSingle = nullptr;
     radioMultiple = nullptr;
     ButtonOpenTDB = nullptr;

--- a/vbin.h
+++ b/vbin.h
@@ -103,12 +103,8 @@ public:
     void readData(long sceneLocation);
     void getSceneNodeTree(long searchStart, long searchEnd, int depth);
     void readNode();
-//    void readMesh();
-//    void readAnimationPrototype();
-//    void readModifications();
-//    void readBoundingVolume();
-//    void getSceneNodeTree2();
-    void getModifications();
+    void readModifications();
+    //void getModifications();
     void modifyPosArrays(std::vector<Modifications> addedMods);
     void printInfo(int depth); // for debugging
     const void operator=(FileSection input);
@@ -149,10 +145,10 @@ public:
 private:
     //void modifyPosArrays();
     void outputPositionList(int location);
-    void readModifications();
     void readAnimationPrototype();
     void readBoundingVolume();
     int getSceneNodeTree();
+    void readModifications();
     void analyzeTriangles(std::vector<int> indArrays, int whichArray);
     QVector3D needOffset(int offsetLocation);
     QQuaternion getRotation(int offsetLocation);


### PR DESCRIPTION
Multi-file outputs now work correctly
VBIN models without LOD levels will now properly export 
Models with SurfaceProperties version 1 or 3 will now read correctly 
Models with a mesh as their root instead of a scene node will now export 
LOD-less models with multiple elements now export correctly 
Models with animation data before their mesh data now read correctly 
Scale offsets are now applied before rotation offsets for more accurate exports