### PR TITLE
v5.4 DAE Exports and Texture Swizzling

### DIFF
--- a/Antioch2.cpp
+++ b/Antioch2.cpp
@@ -1,0 +1,255 @@
+#include "mainwindow.h"
+
+AnimationBase *makeAnimation(QString animationSignature){
+    if (animationSignature == "~anAnimationTranslation") {
+        return new AnimationTranslation;
+    } else if (animationSignature == "~anAnimationOrientation") {
+        return new AnimationOrientation;
+    } /*else if (animationSignature == "~anAnimationScale") {
+        return new AnimationScale;
+    } else {
+        return nullptr;
+    }*/
+    return nullptr;
+}
+
+void AnimationSourceSet::readAnimationSet(){
+    unknownValue1 = file->fileData->readInt();
+    animationCount = file->fileData->readInt();
+
+
+    if(file->fileData->getSignature() != "~StreamArray"){
+        qDebug() << Q_FUNC_INFO << "Expected Stream Array at" << file->fileData->currentPosition;
+        return;
+    }
+
+    int arrayLength = file->fileData->readInt();
+
+    for (int animation = 0; animation < animationCount; animation++) {
+        AnimationStream *animationStream = new AnimationStream;
+        animationStream->file = file;
+        animationStream->readAnimationStream();
+        streamArray.push_back(animationStream);
+    }
+}
+
+void AnimationStream::readAnimationStream(){
+    if (file->fileData->getSignature() != "~anAnimationStream") {
+        qDebug() << Q_FUNC_INFO << "Expected Animation Stream at" << file->fileData->currentPosition;
+        return;
+    }
+
+    int nameLength = file->fileData->readInt();
+    name = file->fileData->readHex(nameLength);
+    sectionLength = file->fileData->readInt();
+
+    unknownValue1 = file->fileData->readInt();
+    unknownValue2 = file->fileData->readInt();
+    unknownValue3 = file->fileData->readInt();
+    unknownValue4 = file->fileData->readInt();
+    unknownFloat1 = file->fileData->readFloat();
+    channelCount = file->fileData->readInt();
+
+    if (file->fileData->getSignature() != "~channelArray") {
+        qDebug() << Q_FUNC_INFO << "Expected Channel Array at" << file->fileData->currentPosition;
+        return;
+    }
+
+    int channelDataLength = file->fileData->readInt();
+
+    for(int channel = 0; channel < channelCount; channel++){
+        QString channelType = file->fileData->getSignature();
+        nameLength = file->fileData->readInt();
+        QString tempName = file->fileData->readHex(nameLength);
+        int tempLength = file->fileData->readInt();
+        int ending = file->fileData->currentPosition - 4 + tempLength;
+
+        AnimationBase *animationChannel = makeAnimation(channelType);
+        if (animationChannel == nullptr) {
+            qDebug() << Q_FUNC_INFO << "Unsupported channel type" << channelType << ". Skipping for now.";
+            file->parent->fileData.currentPosition = ending;
+            continue;
+        }
+        qDebug() << Q_FUNC_INFO << "reading an animation channel" << tempName << "of type" << channelType << "at" << file->fileData->currentPosition;
+        animationChannel->file = file;
+        animationChannel->animationType = channelType;
+
+        animationChannel->name = tempName;
+        animationChannel->sectionLength = tempLength;
+        animationChannel->unknownValue1 = file->fileData->readInt();
+        animationChannel->unknownValue2 = file->fileData->readInt();
+        animationChannel->unknownValue3 = file->fileData->readInt();
+        if(channelType == "~anAnimationOrientation"){
+            animationChannel->unknownValue4 = file->fileData->readInt(2);
+        }
+
+        QString motionType = file->fileData->getSignature();
+        if(motionType == "Scalar"){
+            animationChannel->readScalar();
+            motionType = file->fileData->getSignature();
+        }
+
+        if (motionType == "~Linear") {
+            animationChannel->readLinear();
+        } else if (motionType == "~Cubic") {
+            animationChannel->readCubic();
+        } else if (motionType == "~CubicC2") {
+            animationChannel->readCubicC2();
+        } else {
+            qDebug() << Q_FUNC_INFO << "Unsupported motion type" << motionType << ". Skipping for now.";
+            file->fileData->currentPosition = ending;
+        }
+        animationChannel->maxTime = 0;
+        for(int i = 0; i < animationChannel->keyframeTimes.size(); i++){
+            if(animationChannel->keyframeTimes[i] > animationChannel->maxTime){
+                animationChannel->maxTime = animationChannel->keyframeTimes[i];
+            }
+        }
+        channelArray.push_back(animationChannel);
+    }
+}
+
+void AnimationBase::readScalar(){
+    qDebug() << Q_FUNC_INFO << "reading an animation scalar modifier";
+    hasScalar = true;
+    sectionLength = file->fileData->readInt();
+    unknownValue1 = file->fileData->readInt();
+    keyframeCount = file->fileData->readInt();
+    unknownValue2 = file->fileData->readInt();
+    float x_pos = file->fileData->readFloat();
+    float y_pos = file->fileData->readFloat();
+    float z_pos = file->fileData->readFloat();
+    vectorList.push_back(QVector3D(x_pos, y_pos, z_pos));
+}
+
+void AnimationTranslation::readLinear(){
+    qDebug() << Q_FUNC_INFO << "reading a translation animation linear motion";
+    sectionLength = file->fileData->readInt();
+    unknownValue1 = file->fileData->readInt();
+    keyframeCount = file->fileData->readInt();
+    unknownValue2 = file->fileData->readInt();
+    qDebug() << Q_FUNC_INFO << "reading" << keyframeCount << "values";
+    for (int frameData = 0; frameData < keyframeCount; frameData++) {
+        keyframeTimes.push_back(file->parent->fileData.readFloat());
+        float x_pos = file->fileData->readFloat();
+        float y_pos = file->fileData->readFloat();
+        float z_pos = file->fileData->readFloat();
+        vectorList.push_back(QVector3D(x_pos, y_pos, z_pos));
+    }
+}
+
+void AnimationTranslation::readCubic(){
+    if(hasScalar){
+        qDebug() << Q_FUNC_INFO << "reading a translation animation cubic motion";
+        sectionLength = file->fileData->readInt();
+        unknownValue1 = file->fileData->readInt();
+        keyframeCount = file->fileData->readInt();
+        unknownValue2 = file->fileData->readInt();
+        qDebug() << Q_FUNC_INFO << "reading" << keyframeCount << "values at" << file->fileData->currentPosition;
+        for (int frameData = 0; frameData < keyframeCount; frameData++) {
+            keyframeTimes.push_back(file->parent->fileData.readFloat());
+            float x_pos = file->parent->fileData.readFloat();
+            float y_pos = file->parent->fileData.readFloat();
+            float z_pos = file->parent->fileData.readFloat();
+            vectorList.push_back(QVector3D(x_pos, y_pos, z_pos));
+        }
+    } else {
+        keyframeTimes.push_back(file->parent->fileData.readFloat());
+        for(int i = 0; i < 3; i++){
+            float x_pos = file->parent->fileData.readFloat();
+            float y_pos = file->parent->fileData.readFloat();
+            float z_pos = file->parent->fileData.readFloat();
+            vectorList.push_back(QVector3D(x_pos, y_pos, z_pos));
+        }
+    }
+}
+
+void AnimationOrientation::readLinear(){
+    qDebug() << Q_FUNC_INFO << "reading an orientation animation linear motion";
+    sectionLength = file->fileData->readInt();
+    unknownValue1 = file->fileData->readInt();
+    keyframeCount = file->fileData->readInt();
+    unknownValue2 = file->fileData->readInt();
+    qDebug() << Q_FUNC_INFO << "reading" << keyframeCount << "values at" << file->fileData->currentPosition;
+    for (int frameData = 0; frameData < keyframeCount; frameData++) {
+        keyframeTimes.push_back(file->parent->fileData.readFloat());
+        if (unknownValue4) {
+            rotationList.push_back(file->fileData->readMiniQuaternion());
+        } else {
+            rotationList.push_back(file->fileData->readQuaternion());
+        }
+    }
+}
+
+void AnimationOrientation::readCubic(){
+    //might need to add check for miniquat
+    if(hasScalar){
+        qDebug() << Q_FUNC_INFO << "reading an orientation animation cubic motion";
+        sectionLength = file->parent->fileData.readInt();
+        unknownValue1 = file->parent->fileData.readInt();
+        keyframeCount = file->parent->fileData.readInt();
+        unknownValue2 = file->parent->fileData.readInt();
+        qDebug() << Q_FUNC_INFO << "reading" << keyframeCount << "values";
+        for (int frameData = 0; frameData < keyframeCount; frameData++) {
+            keyframeTimes.push_back(file->parent->fileData.readFloat());
+            rotationList.push_back(file->fileData->readMiniQuaternion());
+        }
+    } else {
+        keyframeTimes.push_back(file->parent->fileData.readFloat());
+        for(int i = 0; i < 3; i++){
+            rotationList.push_back(file->fileData->readMiniQuaternion());
+        }
+    }
+}
+
+void AnimationOrientation::readCubicC2(){
+    //might need to add check for miniquat
+    qDebug() << Q_FUNC_INFO << "reading an orientation animation cubic2 motion";
+    sectionLength = file->parent->fileData.readInt();
+    unknownValue1 = file->parent->fileData.readInt();
+    keyframeCount = file->parent->fileData.readInt();
+    unknownValue2 = file->parent->fileData.readInt();
+    qDebug() << Q_FUNC_INFO << "reading" << keyframeCount << "values";
+    for (int frameData = 0; frameData < keyframeCount; frameData++) {
+        keyframeTimes.push_back(file->parent->fileData.readFloat());
+        rotationList.push_back(file->fileData->readMiniQuaternion());
+        velocityList2.push_back(file->fileData->readMiniQuaternion());
+        qDebug() << Q_FUNC_INFO << "keyframe" << keyframeTimes[frameData] << "has rotation" << rotationList[frameData] << "and velocity" << velocityList2[frameData];
+    }
+}
+
+void AnimationTranslation::readCubicC2(){
+    qDebug() << Q_FUNC_INFO << "reading an translation animation cubic2 motion";
+    sectionLength = file->parent->fileData.readInt();
+    unknownValue1 = file->parent->fileData.readInt();
+    keyframeCount = file->parent->fileData.readInt();
+    unknownValue2 = file->parent->fileData.readInt();
+    qDebug() << Q_FUNC_INFO << "reading" << keyframeCount << "values";
+    for (int frameData = 0; frameData < keyframeCount; frameData++) {
+        keyframeTimes.push_back(file->parent->fileData.readFloat());
+        vectorList.push_back(file->fileData->readVector());
+        velocityList.push_back(file->fileData->readVector());
+        qDebug() << Q_FUNC_INFO << "keyframe" << keyframeTimes[frameData] << "has offset" << vectorList[frameData];
+    }
+}
+
+float AnimationBase::findSplineAtTime(float time){
+    for (int i = 0; i < keyframeTimes.size()-1; i++) {
+        if(time > keyframeTimes[i] && time < keyframeTimes[i+1]){
+            return (time - keyframeTimes[i]) / (keyframeTimes[i+1] - keyframeTimes[i]);
+        }
+    }
+    return 0;
+}
+
+void AnimationBase::readLinear(){
+    file->parent->messageError("THIS SHOULD NOT RUN");
+}
+
+void AnimationBase::readCubic(){
+    file->parent->messageError("THIS SHOULD NOT RUN");
+}
+
+void AnimationBase::readCubicC2(){
+    file->parent->messageError("THIS SHOULD NOT RUN");
+}

--- a/Antioch2.h
+++ b/Antioch2.h
@@ -1,0 +1,97 @@
+#ifndef ANTIOCH2_H
+#define ANTIOCH2_H
+
+#include <QVector>
+#include <QQuaternion>
+
+class VBIN;
+
+class AnimationBase{
+public:
+    VBIN *file;
+    QString name;
+    long sectionLength;
+    long sectionEnd;
+    QString animationType; //Linear, cubic, scalar, etc
+
+    int unknownValue1;
+    int unknownValue2;
+    int unknownValue3;
+    int unknownValue4;
+    int keyframeCount;
+    int unknownValue5;
+
+    float maxTime;
+
+    std::vector<float> keyframeTimes;
+
+    std::vector<QVector3D> vectorList;
+    std::vector<QQuaternion> rotationList;
+    std::vector<QVector3D> velocityList;
+    std::vector<QQuaternion> velocityList2;
+    float scale;
+    bool hasScalar;
+
+    static AnimationBase *makeAnimation(QString animationSignature);
+    float findSplineAtTime(float time);
+    virtual void readLinear();
+    virtual void readCubic();
+    virtual void readCubicC2();
+
+
+    void readScalar();
+};
+
+class AnimationTranslation : public AnimationBase {
+public:
+    void readLinear();
+    void readCubic();
+    void readCubicC2();
+};
+
+class AnimationOrientation : public AnimationBase {
+    void readLinear();
+    void readCubic();
+    void readCubicC2();
+};
+
+class AnimationScale : public AnimationBase {
+};
+
+class AnimationStream{
+public:
+    VBIN* file;
+    long fileLocation;
+    QString name;
+    long sectionLength;
+    long sectionEnd;
+
+    int unknownValue1;
+    int unknownValue2;
+    int unknownValue3;
+    int unknownValue4;
+    float unknownFloat1;
+    int channelCount;
+
+    std::vector<AnimationBase*> channelArray;
+
+    void readAnimationStream();
+};
+
+class AnimationSourceSet{
+  public:
+    VBIN* file;
+    long fileLocation;
+    QString name;
+    long sectionLength;
+    long sectionEnd;
+
+    int unknownValue1;
+    int animationCount;
+
+    std::vector<AnimationStream*> streamArray;
+
+    void readAnimationSet();
+};
+
+#endif // ANTIOCH2_H

--- a/BinChanger.cpp
+++ b/BinChanger.cpp
@@ -37,6 +37,44 @@ float FileData::readFloat(int length, long location){
     return readValue;
 }
 
+float FileData::readMiniFloat(int length, long location){
+    QString readBin = parent->binChanger.reverse_input(parent->binChanger.hex_to_bin(dataBytes.mid(currentPosition + location, length)), 8);
+    int twoscompread = parent->binChanger.twosCompConv(readBin, 8);
+    float reduceInt = float(twoscompread) / 30000;
+    //qDebug() << Q_FUNC_INFO << "int read:" << float(twoscompread) << "then becomes" << reduceInt;
+    currentPosition += length;
+    return reduceInt;
+}
+
+QVector3D FileData::readVector(int length, long location){
+    float x_value = readFloat();
+    float y_value = readFloat();
+    float z_value = readFloat();
+    QVector3D vector = QVector3D(x_value, y_value, z_value);
+
+    return vector;
+}
+
+QQuaternion FileData::readQuaternion(int length, long location){
+    float x_value = readFloat();
+    float y_value = readFloat();
+    float z_value = readFloat();
+    float m_value = readFloat();
+    QQuaternion rotation = QQuaternion(m_value, x_value, y_value, z_value);
+
+    return rotation;
+}
+
+QQuaternion FileData::readMiniQuaternion(int length, long location){
+    float x_value = readMiniFloat();
+    float y_value = readMiniFloat();
+    float z_value = readMiniFloat();
+    float m_value = readMiniFloat();
+    QQuaternion rotation = QQuaternion(m_value, x_value, y_value, z_value);
+
+    return rotation;
+}
+
 QByteArray FileData::readHex(int length, long location){
     QByteArray readValue = dataBytes.mid(currentPosition + location, length);
     currentPosition += length;
@@ -82,7 +120,7 @@ QString FileData::getSignature(){
 
     //qDebug() << Q_FUNC_INFO << "reading signature at " << signatureStart;
     signature = mid(signatureStart, signatureEnd-signatureStart);
-    //qDebug() << Q_FUNC_INFO << "signature read as " << signature;
+    //qDebug() << Q_FUNC_INFO << "signature read as " << signature << "at" << signatureStart;
     currentPosition = signatureEnd+2;
     //qDebug() << Q_FUNC_INFO << "post-signature bytes:" << readInt(2);
     return signature;

--- a/BinChanger.h
+++ b/BinChanger.h
@@ -44,6 +44,10 @@ class FileData{
     int readUInt(int length = 4, long location = 0);
     bool readBool(int length = 1, long location = 0);
     float readFloat(int length = 4, long location = 0);
+    float readMiniFloat(int length = 2, long location = 0);
+    QVector3D readVector(int length = 4, long location = 0);
+    QQuaternion readQuaternion(int length = 4, long location = 0);
+    QQuaternion readMiniQuaternion(int length = 2, long location = 0);
     QByteArray readHex(int length, long location = 0);
     QByteArray mid(long location, int length);
     QString getSignature();

--- a/DistanceCalculations.h
+++ b/DistanceCalculations.h
@@ -1,0 +1,16 @@
+#ifndef DISTANCECALCULATIONS_H
+#define DISTANCECALCULATIONS_H
+
+#include <QString>
+
+class Warpgate{
+public:
+    float x_value;
+    float y_value;
+    float z_value;
+    QString name;
+
+    static std::vector<Warpgate> createAmazonWarpgates();
+};
+
+#endif // DISTANCECALCULATIONS_H

--- a/Mesh.cpp
+++ b/Mesh.cpp
@@ -4,7 +4,7 @@ void LODInfo::clear(){
     levels= 0;
     targetIndecies.clear();
     fileLocation = 0;
-    file = nullptr;
+    fileData = nullptr;
 }
 
 void PositionArray::clear(){
@@ -13,7 +13,7 @@ void PositionArray::clear(){
     fileLocation = 0;
     meshName = "";
     positionList.clear();
-    file = nullptr;
+    fileData = nullptr;
 }
 
 void Mesh::clear(){
@@ -24,6 +24,7 @@ void Mesh::clear(){
     sectionList.clear();
     sectionTypes.clear();
     file = nullptr;
+    fileData = nullptr;
 }
 
 const void Mesh::operator=(Mesh input){
@@ -35,7 +36,7 @@ const void Mesh::operator=(Mesh input){
     sectionList = input.sectionList;
     sectionTypes = input.sectionTypes;
     elementArray.lodInfo = input.elementArray.lodInfo;
-    elementArray.lodInfo.file = input.elementArray.lodInfo.file;
+    elementArray.lodInfo.fileData = input.elementArray.lodInfo.fileData;
     elementArray.lodInfo.fileLocation = input.elementArray.lodInfo.fileLocation;
     elementArray.lodInfo.levels = input.elementArray.lodInfo.levels;
     elementArray.lodInfo.targetIndecies = input.elementArray.lodInfo.targetIndecies;
@@ -43,7 +44,7 @@ const void Mesh::operator=(Mesh input){
 
 const void PositionArray::operator=(PositionArray input){
     arrayID = input.arrayID;
-    file = input.file;
+    fileData = input.fileData;
     meshName = input.meshName;
     positionList = input.positionList;
     vertexCount = input.vertexCount;
@@ -63,38 +64,40 @@ int Mesh::readMesh(){
     float z_position = 0;
     float a_position = 0;
     //qDebug() << Q_FUNC_INFO << "Do mesh stuff";
-    elementCount = file->parent->fileData.readInt();
-    signature = file->parent->fileData.getSignature(); //get extended info
+    elementCount = fileData->readInt();
+    signature = fileData->getSignature(); //get extended info
     if(signature == "~ExtendedInfo"){
-        subSectionLength = file->parent->fileData.readInt();
-        file->parent->fileData.currentPosition += subSectionLength-4;
-        signature = file->parent->fileData.getSignature(); //then read vertex set
+        subSectionLength = fileData->readInt();
+        fileData->currentPosition += subSectionLength-4;
+        signature = fileData->getSignature(); //then read vertex set
     }
     if (signature != "~VertexSet") {
-        qDebug() << Q_FUNC_INFO << "Expected VertexSet. Unexpected section found at " << file->parent->fileData.currentPosition << ": " << signature;
+        qDebug() << Q_FUNC_INFO << "Expected VertexSet. Unexpected section found at " << fileData->currentPosition << ": " << signature;
         return 1;
     }
 
-    subSectionLength = file->parent->fileData.readInt();
-    //file->parent->fileData.currentPosition += subSectionLength - 4;
-    vertexSet.vertexCount = file->parent->fileData.readInt();
-    int unknown4Byte2 = file->parent->fileData.readInt();
-    int unknown4Byte3 = file->parent->fileData.readInt();
+    subSectionLength = fileData->readInt();
+    //fileData->currentPosition += subSectionLength - 4;
+    vertexSet.vertexCount = fileData->readInt();
+    //qDebug() << Q_FUNC_INFO << "reading unknown values at" << fileData->currentPosition;
+    int unknown4Byte1 = fileData->readInt();
+    int unknown4Byte2 = fileData->readInt();
+    //qDebug() << Q_FUNC_INFO << "unknown1" << unknown4Byte1 << "unknown2" << unknown4Byte2;
 
     //Position Array
-    signature = file->parent->fileData.getSignature();
+    signature = fileData->getSignature();
     if (signature == "~PositionArray") {
-        subSectionLength = file->parent->fileData.readInt();
+        subSectionLength = fileData->readInt();
 
         for(int position = 0; position < (subSectionLength-4)/12; position++){
-            x_position = file->parent->fileData.readFloat();
-            //qDebug() << Q_FUNC_INFO << "X float: " << x_position << " from hex: " << file->parent->binChanger.reverse_input(file->parent->fileData.mid(positionLocation + (i*12), 4).toHex(), 2);
-            y_position = file->parent->fileData.readFloat();
-            z_position = file->parent->fileData.readFloat();
+            x_position = fileData->readFloat();
+            //qDebug() << Q_FUNC_INFO << "X float: " << x_position << " from hex: " << file->parent->binChanger.reverse_input(fileData->mid(positionLocation + (i*12), 4).toHex(), 2);
+            y_position = fileData->readFloat();
+            z_position = fileData->readFloat();
             vertexSet.positionArray.positionList.push_back(QVector3D(x_position, y_position, z_position));
         }
 
-        signature = file->parent->fileData.getSignature();
+        signature = fileData->getSignature();
     } else {
         qDebug() << Q_FUNC_INFO << "Model does not have PositionArray";
     }
@@ -102,17 +105,16 @@ int Mesh::readMesh(){
 
     //Normal Array
     if (signature == "~NormalArray") {
-        subSectionLength = file->parent->fileData.readInt();
+        subSectionLength = fileData->readInt();
 
         for(int position = 0; position < (subSectionLength-4)/12; position++){
-            x_position = file->parent->fileData.readFloat();
-            //qDebug() << Q_FUNC_INFO << "X float: " << x_position << " from hex: " << file->parent->binChanger.reverse_input(file->parent->fileData.mid(positionLocation + (i*12), 4).toHex(), 2);
-            y_position = file->parent->fileData.readFloat();
-            z_position = file->parent->fileData.readFloat();
+            x_position = fileData->readFloat();
+            y_position = fileData->readFloat();
+            z_position = fileData->readFloat();
             vertexSet.normalArray.positionList.push_back(QVector3D(x_position, y_position, z_position));
         }
 
-        signature = file->parent->fileData.getSignature();
+        signature = fileData->getSignature();
     } else {
         qDebug() << Q_FUNC_INFO << "Model does not have NormalArray";
     }
@@ -120,18 +122,18 @@ int Mesh::readMesh(){
 
     //Color Array
     if (signature == "~ColorArray") {
-        subSectionLength = file->parent->fileData.readInt();
+        subSectionLength = fileData->readInt();
 
         for(int position = 0; position < (subSectionLength-4)/16; position++){
-            x_position = file->parent->fileData.readFloat();
-            //qDebug() << Q_FUNC_INFO << "X float: " << x_position << " from hex: " << file->parent->binChanger.reverse_input(file->parent->fileData.mid(positionLocation + (i*12), 4).toHex(), 2);
-            y_position = file->parent->fileData.readFloat();
-            z_position = file->parent->fileData.readFloat();
-            a_position = file->parent->fileData.readFloat();
+            x_position = fileData->readFloat();
+            //qDebug() << Q_FUNC_INFO << "X float: " << x_position << " from hex: " << file->parent->binChanger.reverse_input(fileData->mid(positionLocation + (i*12), 4).toHex(), 2);
+            y_position = fileData->readFloat();
+            z_position = fileData->readFloat();
+            a_position = fileData->readFloat();
             vertexSet.colorArray.positionList.push_back(QVector4D(x_position, y_position, z_position, a_position));
         }
 
-        signature = file->parent->fileData.getSignature();
+        signature = fileData->getSignature();
     } else {
         qDebug() << Q_FUNC_INFO << "Model does not have ColorArray.";
     }
@@ -139,62 +141,64 @@ int Mesh::readMesh(){
 
     //Texture Coords
     if (signature == "~TextureCoords") {
-        subSectionLength = file->parent->fileData.readInt();
+        subSectionLength = fileData->readInt();
 
         for(int position = 0; position < (subSectionLength-4)/8; position++){
-            x_position = file->parent->fileData.readFloat();
-            y_position = file->parent->fileData.readFloat();
+            x_position = fileData->readFloat();
+            y_position = fileData->readFloat();
             vertexSet.textureCoords.positionList.push_back(QVector2D(x_position, y_position));
         }
 
-        signature = file->parent->fileData.getSignature();
+        signature = fileData->getSignature();
     } else {
         qDebug() << Q_FUNC_INFO << "Model does not have TextureCoords.";
     }
 
     //Element Array
     if (signature != "~ElementArray") {
-        qDebug() << Q_FUNC_INFO << "Expected ElementArray. Unexpected section found at " << file->parent->fileData.currentPosition << ": " << signature;
+        qDebug() << Q_FUNC_INFO << "Expected ElementArray. Unexpected section found at " << fileData->currentPosition << ": " << signature;
         return 1;
     }
     //ElementArray *elementArray = new ElementArray;
-    subSectionLength = file->parent->fileData.readInt();
-    subSectionEnd = file->parent->fileData.currentPosition - 4 + subSectionLength;
+    subSectionLength = fileData->readInt();
+    subSectionEnd = fileData->currentPosition - 4 + subSectionLength;
     for(int readElement = 0; readElement < elementCount; readElement++){
         Element *element = new Element;
-        signature = file->parent->fileData.getSignature();
-        subSectionLength = file->parent->fileData.readInt();
+        signature = fileData->getSignature();
+        subSectionLength = fileData->readInt();
+        element->meshFaceSet.indexArray.triangleCount = 0;
         //need to check for LODINFO bit to see if we even read LODInfo
         if (signature == "~LODInfo") {
-            qDebug() << Q_FUNC_INFO << "Reached LOD Info at " << file->parent->fileData.currentPosition << ": " << signature;
+            qDebug() << Q_FUNC_INFO << "Reached LOD Info at " << fileData->currentPosition << ": " << signature;
             break;
         }
-        element->unknownProperty1 = file->parent->fileData.readInt();
+        element->unknownProperty1 = fileData->readInt();
 
-        signature = file->parent->fileData.getSignature();
+        signature = fileData->getSignature();
         if (signature != "~MeshFaceSet") {
-            qDebug() << Q_FUNC_INFO << "Expected MeshFaceSet. Unexpected section found at " << file->parent->fileData.currentPosition << ": " << signature;
+            qDebug() << Q_FUNC_INFO << "Expected MeshFaceSet. Unexpected section found at " << fileData->currentPosition << ": " << signature;
             return 1;
         }
-        subSectionLength = file->parent->fileData.readInt();
-        element->meshFaceSet.unknownProperty1 = file->parent->fileData.readInt();
-        element->meshFaceSet.unknownProperty2 = file->parent->fileData.readInt();
-        element->meshFaceSet.unknownProperty3 = file->parent->fileData.readInt();
+        subSectionLength = fileData->readInt();
+        element->meshFaceSet.unknownProperty1 = fileData->readInt();
+        element->meshFaceSet.unknownProperty2 = fileData->readInt();
+        element->meshFaceSet.unknownProperty3 = fileData->readInt();
 
-        signature = file->parent->fileData.getSignature();
+        signature = fileData->getSignature();
         if (signature != "~IndexArray") {
-            qDebug() << Q_FUNC_INFO << "Expected IndexArray. Unexpected section found at " << file->parent->fileData.currentPosition << ": " << signature;
+            qDebug() << Q_FUNC_INFO << "Expected IndexArray. Unexpected section found at " << fileData->currentPosition << ": " << signature;
             return 1;
         }
-        subSectionLength = file->parent->fileData.readInt();
-        indexEnd = file->parent->fileData.currentPosition - 4 + subSectionLength;
+        subSectionLength = fileData->readInt();
+        indexEnd = fileData->currentPosition - 4 + subSectionLength;
         //skipping IndexArray for now
-        //file->parent->fileData.currentPosition += subSectionLength - 4;
-        while(file->parent->fileData.currentPosition < indexEnd){
+        //fileData->currentPosition += subSectionLength - 4;
+        while(fileData->currentPosition < indexEnd){
             TriangleStrip *triangleStrip = new TriangleStrip;
-            triangleStrip->stripIndecies.resize(file->parent->fileData.readInt(2));
+            triangleStrip->stripIndecies.resize(fileData->readInt(2));
             for (int triangle = 0; triangle<triangleStrip->stripIndecies.size();triangle++){
-                triangleStrip->stripIndecies[triangle] = file->parent->fileData.readInt(2);
+                element->meshFaceSet.indexArray.triangleCount += 1;
+                triangleStrip->stripIndecies[triangle] = fileData->readInt(2);
             }
             element->meshFaceSet.indexArray.triangleStrips.push_back(*triangleStrip);
         }
@@ -204,99 +208,113 @@ int Mesh::readMesh(){
             //qDebug() << Q_FUNC_INFO << "Triangle Strip " << i << ": " << element->meshFaceSet.indexArray.triangleStrips[i].stripIndecies.size();
         }
 
-        signature = file->parent->fileData.getSignature();
+        signature = fileData->getSignature();
         if (signature != "~SurfaceProperties") {
-            qDebug() << Q_FUNC_INFO << "Expected SurfaceProperties. Unexpected section found at " << file->parent->fileData.currentPosition << ": " << signature;
+            qDebug() << Q_FUNC_INFO << "Expected SurfaceProperties. Unexpected section found at " << fileData->currentPosition << ": " << signature;
             return 1;
         }
-        subSectionLength = file->parent->fileData.readInt();
-        element->surfaceProperties.materialRelated = file->parent->fileData.readInt();
-        nameLength = file->parent->fileData.readInt();
-        element->surfaceProperties.name = file->parent->fileData.readHex(nameLength);
-        element->surfaceProperties.unknownProperty2 = file->parent->fileData.readInt();
+        subSectionLength = fileData->readInt();
+        element->surfaceProperties.materialRelated = fileData->readInt(); //seems like a version number
+        nameLength = fileData->readInt();
+        element->surfaceProperties.textureName = fileData->readHex(nameLength);
+        element->surfaceProperties.unknownProperty2 = fileData->readInt();
 
-        signature = file->parent->fileData.getSignature();
+        signature = fileData->getSignature();
         if (signature != "~Material") {
-            qDebug() << Q_FUNC_INFO << "Expected Material. Unexpected section found at " << file->parent->fileData.currentPosition << ": " << signature;
+            qDebug() << Q_FUNC_INFO << "Expected Material. Unexpected section found at " << fileData->currentPosition << ": " << signature;
             return 1;
         }
-        subSectionLength = file->parent->fileData.readInt();
+        subSectionLength = fileData->readInt();
 
         if(element->surfaceProperties.materialRelated == 5){
-            element->surfaceProperties.material.unknownProperty1 = file->parent->fileData.readInt();
+            //materialRelated 3 is seen on TFA/PICKUPS models, 4 is seen on LightningRod
+            element->surfaceProperties.material.unknownProperty1 = fileData->readInt();
 
-            element->surfaceProperties.material.nameLength = file->parent->fileData.readInt();
-            element->surfaceProperties.material.name = file->parent->fileData.readHex(element->surfaceProperties.material.nameLength);
+            element->surfaceProperties.material.nameLength = fileData->readInt();
+            element->surfaceProperties.material.name = fileData->readHex(element->surfaceProperties.material.nameLength);
         }
 
-        element->surfaceProperties.material.unknownFloat1 = file->parent->fileData.readFloat();
-        element->surfaceProperties.material.unknownFloat2 = file->parent->fileData.readFloat();
-        element->surfaceProperties.material.unknownFloat3 = file->parent->fileData.readFloat();
-        element->surfaceProperties.material.unknownFloat4 = file->parent->fileData.readFloat();
-        element->surfaceProperties.material.unknownFloat5 = file->parent->fileData.readFloat();
-        element->surfaceProperties.material.unknownFloat6 = file->parent->fileData.readFloat();
-        element->surfaceProperties.material.unknownFloat7 = file->parent->fileData.readFloat();
-        element->surfaceProperties.material.unknownFloat8 = file->parent->fileData.readFloat();
-        element->surfaceProperties.material.unknownFloat9 = file->parent->fileData.readFloat();
-        element->surfaceProperties.material.unknownFloat10 = file->parent->fileData.readFloat();
-        element->surfaceProperties.material.unknownFloat11 = file->parent->fileData.readFloat();
-        element->surfaceProperties.material.unknownFloat12 = file->parent->fileData.readFloat();
-        element->surfaceProperties.material.unknownFloat13 = file->parent->fileData.readFloat();
+        element->surfaceProperties.material.unknownFloat1 = fileData->readFloat();
+        element->surfaceProperties.material.unknownFloat2 = fileData->readFloat();
+        element->surfaceProperties.material.unknownFloat3 = fileData->readFloat();
+        element->surfaceProperties.material.unknownFloat4 = fileData->readFloat();
+        element->surfaceProperties.material.unknownFloat5 = fileData->readFloat();
+        element->surfaceProperties.material.unknownFloat6 = fileData->readFloat();
+        element->surfaceProperties.material.unknownFloat7 = fileData->readFloat();
+        element->surfaceProperties.material.unknownFloat8 = fileData->readFloat();
+        element->surfaceProperties.material.unknownFloat9 = fileData->readFloat();
+        element->surfaceProperties.material.unknownFloat10 = fileData->readFloat();
+        element->surfaceProperties.material.unknownFloat11 = fileData->readFloat();
+        element->surfaceProperties.material.unknownFloat12 = fileData->readFloat();
+        element->surfaceProperties.material.unknownFloat13 = fileData->readFloat();
 
 
-        signature = file->parent->fileData.getSignature();
+        signature = fileData->getSignature();
         if (signature != "~RenderStateGroup") {
-            qDebug() << Q_FUNC_INFO << "Expected RenderStateGroup. Unexpected section found at " << file->parent->fileData.currentPosition << ": " << signature;
+            qDebug() << Q_FUNC_INFO << "Expected RenderStateGroup. Unexpected section found at " << fileData->currentPosition << ": " << signature;
             return 1;
         }
-        subSectionLength = file->parent->fileData.readInt();
-        element->surfaceProperties.renderStateGroup1.unknownProperty1 = file->parent->fileData.readInt();
-        element->surfaceProperties.renderStateGroup1.unknownProperty2 = file->parent->fileData.readInt();
-        element->surfaceProperties.renderStateGroup1.unknownProperty3 = file->parent->fileData.readInt();
-        element->surfaceProperties.renderStateGroup1.unknownProperty4 = file->parent->fileData.readInt();
-        element->surfaceProperties.renderStateGroup1.unknownProperty5 = file->parent->fileData.readInt();
-        element->surfaceProperties.renderStateGroup1.unknownProperty6 = file->parent->fileData.readInt();
-        element->surfaceProperties.renderStateGroup1.unknownProperty7 = file->parent->fileData.readInt();
+        subSectionLength = fileData->readInt();
+        element->surfaceProperties.renderStateGroup1.unknownProperty1 = fileData->readInt();
+        element->surfaceProperties.renderStateGroup1.unknownProperty2 = fileData->readInt();
+        element->surfaceProperties.renderStateGroup1.unknownProperty3 = fileData->readInt();
+        element->surfaceProperties.renderStateGroup1.unknownProperty4 = fileData->readInt();
+        element->surfaceProperties.renderStateGroup1.unknownProperty5 = fileData->readInt();
+        element->surfaceProperties.renderStateGroup1.unknownProperty6 = fileData->readInt();
+        element->surfaceProperties.renderStateGroup1.unknownProperty7 = fileData->readInt();
 
-        signature = file->parent->fileData.getSignature();
-        if (signature != "~RenderStateGroup") {
-            qDebug() << Q_FUNC_INFO << "Expected RenderStateGroup. Unexpected section found at " << file->parent->fileData.currentPosition << ": " << signature;
-            return 1;
+        //qDebug() << Q_FUNC_INFO << "material version number" << element->surfaceProperties.materialRelated;
+        if(element->surfaceProperties.materialRelated > 2){
+            //materialRelated 3 is seen on TFA/PICKUPS models
+            signature = fileData->getSignature();
+            if (signature != "~RenderStateGroup") {
+                qDebug() << Q_FUNC_INFO << "Expected RenderStateGroup. Unexpected section found at " << fileData->currentPosition << ": " << signature;
+                return 1;
+            }
+            subSectionLength = fileData->readInt();
+            element->surfaceProperties.renderStateGroup2.unknownProperty1 = fileData->readInt();
+            element->surfaceProperties.renderStateGroup2.unknownProperty2 = fileData->readInt();
+            element->surfaceProperties.renderStateGroup2.unknownProperty3 = fileData->readInt();
+            element->surfaceProperties.renderStateGroup2.unknownProperty4 = fileData->readInt();
+            element->surfaceProperties.renderStateGroup2.unknownProperty5 = fileData->readInt();
+            element->surfaceProperties.renderStateGroup2.unknownProperty6 = fileData->readInt();
+            element->surfaceProperties.renderStateGroup2.unknownProperty7 = fileData->readInt();
         }
-        subSectionLength = file->parent->fileData.readInt();
-        element->surfaceProperties.renderStateGroup2.unknownProperty1 = file->parent->fileData.readInt();
-        element->surfaceProperties.renderStateGroup2.unknownProperty2 = file->parent->fileData.readInt();
-        element->surfaceProperties.renderStateGroup2.unknownProperty3 = file->parent->fileData.readInt();
-        element->surfaceProperties.renderStateGroup2.unknownProperty4 = file->parent->fileData.readInt();
-        element->surfaceProperties.renderStateGroup2.unknownProperty5 = file->parent->fileData.readInt();
-        element->surfaceProperties.renderStateGroup2.unknownProperty6 = file->parent->fileData.readInt();
-        element->surfaceProperties.renderStateGroup2.unknownProperty7 = file->parent->fileData.readInt();
 
-        element->unknownProperty2 = file->parent->fileData.readInt();
-        element->unknownProperty3 = file->parent->fileData.readInt();
+        element->unknownProperty2 = fileData->readInt();
+
+        if(element->surfaceProperties.materialRelated > 3){
+            element->unknownProperty3 = fileData->readInt();
+        }
 
         elementArray.elementArray.push_back(*element);
     }
 
-    bool hasLodInfo = file->parent->fileData.readBool();
+    bool hasLodInfo = false;
+    //qDebug() << Q_FUNC_INFO << "checking for lod info at" << fileData->currentPosition;
+    if(elementArray.elementArray[0].surfaceProperties.materialRelated > 2){
+        //the use of materialrelated here is absolutely horrible. Find another version number of property byte that can show whether there are LODs or not.
+        hasLodInfo = fileData->readBool();
+    }
+    //qDebug() << Q_FUNC_INFO << "has lod info:" << hasLodInfo;
     if (hasLodInfo) {
-        signature = file->parent->fileData.getSignature();
-        subSectionLength = file->parent->fileData.readInt();
-        elementArray.lodInfo.levels = file->parent->fileData.readInt();
+        signature = fileData->getSignature();
+        subSectionLength = fileData->readInt();
+        elementArray.lodInfo.levels = fileData->readInt();
         std::vector<int> levelTargetArray;
         for (int readLevels = 0; readLevels < elementArray.lodInfo.levels; readLevels++) {
-            levelTargetArray.push_back(file->parent->fileData.readInt());
-            levelTargetArray.push_back(file->parent->fileData.readInt());
+            levelTargetArray.push_back(fileData->readInt());
+            levelTargetArray.push_back(fileData->readInt());
             elementArray.lodInfo.targetIndecies.push_back(levelTargetArray);
             levelTargetArray.clear();
-            elementArray.lodInfo.levelDistance.push_back(file->parent->fileData.readFloat());
+            elementArray.lodInfo.levelDistance.push_back(fileData->readFloat());
         }
         if (elementArray.lodInfo.levels > file->highestLOD){
             file->highestLOD = elementArray.lodInfo.levels;
         }
     }
 
-    //qDebug() << Q_FUNC_INFO << "finished reading mesh at " << file->parent->fileData.currentPosition;
+    //qDebug() << Q_FUNC_INFO << "finished reading mesh at " << fileData->currentPosition;
     return 0;
 
 }
@@ -319,8 +337,104 @@ void Mesh::modify(std::vector<Modifications> addedMods){
     }
 }
 
+void Mesh::writeEffectsDAE(QTextStream &fileOut){
+    std::vector<int> chosenLOD;
+    if (elementArray.lodInfo.targetIndecies.size() <= file->parent->ListLevels->currentIndex()) {
+        chosenLOD = {0,static_cast<int>(elementArray.elementArray.size()-1)};
+    } else {
+        chosenLOD = elementArray.lodInfo.targetIndecies[file->parent->ListLevels->currentText().toInt(nullptr, 10)-1];
+    }
 
-void Mesh::writeData(QTextStream &fileOut){
+    QString meshName = file->fileWithoutExtension + "-" + name;
+
+    QString checkTexture;
+    for(int element = chosenLOD[0]; element <= chosenLOD[1]; element++){
+        checkTexture = elementArray.elementArray[element].surfaceProperties.textureName;
+    }
+    if(checkTexture != elementArray.elementArray[chosenLOD[0]].surfaceProperties.textureName){
+        qDebug() << Q_FUNC_INFO << "checktexture" << checkTexture << "element texture" << elementArray.elementArray[chosenLOD[0]].surfaceProperties.textureName;
+        //file->parent->messageError("Mesh " + name + " has different textures for element " + QString::number(chosenLOD[0]) + " and " + QString::number(chosenLOD[1]) + ". Let Trevor know.");
+        //return;
+    }
+
+    fileOut << "    <effect id=\"" + checkTexture +"Texture-effect\">" << Qt::endl;
+    fileOut << "      <profile_COMMON>" << Qt::endl;
+    fileOut << "        <newparam sid=\"" + checkTexture +"_bmp-surface\">" << Qt::endl;
+    fileOut << "          <surface type=\"2D\">" << Qt::endl;
+    fileOut << "            <init_from>" + checkTexture +"_bmp</init_from>" << Qt::endl;
+    fileOut << "          </surface>" << Qt::endl;
+    fileOut << "        </newparam>" << Qt::endl;
+    fileOut << "        <newparam sid=\"" + checkTexture +"_bmp-sampler\">" << Qt::endl;
+    fileOut << "          <sampler2D>" << Qt::endl;
+    fileOut << "            <source>" + checkTexture +"_bmp-surface</source>" << Qt::endl;
+    fileOut << "          </sampler2D>" << Qt::endl;
+    fileOut << "        </newparam>" << Qt::endl;
+    fileOut << "        <technique sid=\"common\">" << Qt::endl;
+    fileOut << "          <lambert>" << Qt::endl;
+    fileOut << "            <emission>" << Qt::endl;
+    fileOut << "              <color sid=\"emission\">0 0 0 1</color>" << Qt::endl;
+    fileOut << "            </emission>" << Qt::endl;
+    fileOut << "            <diffuse>" << Qt::endl;
+    fileOut << "              <texture texture=\"" + checkTexture +"_bmp-sampler\" texcoord=\""+meshName+"-mesh-texcoords\"/>" << Qt::endl;
+    fileOut << "            </diffuse>" << Qt::endl;
+    fileOut << "            <index_of_refraction>" << Qt::endl;
+    fileOut << "              <float sid=\"ior\">1.45</float>" << Qt::endl;
+    fileOut << "            </index_of_refraction>" << Qt::endl;
+    fileOut << "          </lambert>" << Qt::endl;
+    fileOut << "        </technique>" << Qt::endl;
+    fileOut << "      </profile_COMMON>" << Qt::endl;
+    fileOut << "    </effect>" << Qt::endl;
+}
+
+void Mesh::writeImagesDAE(QTextStream &fileOut){
+    std::vector<int> chosenLOD;
+    if (elementArray.lodInfo.targetIndecies.size() <= file->parent->ListLevels->currentIndex()) {
+        chosenLOD = {0,static_cast<int>(elementArray.elementArray.size()-1)};
+    } else {
+        chosenLOD = elementArray.lodInfo.targetIndecies[file->parent->ListLevels->currentText().toInt(nullptr, 10)-1];
+    }
+
+    QString meshName = file->fileWithoutExtension + "-" + name;
+
+    QString checkTexture;
+    for(int element = chosenLOD[0]; element <= chosenLOD[1]; element++){
+        checkTexture = elementArray.elementArray[element].surfaceProperties.textureName;
+    }
+    if(checkTexture != elementArray.elementArray[chosenLOD[0]].surfaceProperties.textureName){
+        qDebug() << Q_FUNC_INFO << "checktexture" << checkTexture << "element texture" << elementArray.elementArray[chosenLOD[0]].surfaceProperties.textureName;
+        //file->parent->messageError("Mesh " + name + " has different textures for element " + QString::number(chosenLOD[0]) + " and " + QString::number(chosenLOD[1]) + ". Let Trevor know.");
+        //return;
+    }
+    fileOut << "    <image id=\"" + checkTexture +"_bmp\" name=\"" + checkTexture +"_bmp\">" << Qt::endl;
+    fileOut << "      <init_from>" + checkTexture +".bmp</init_from>" << Qt::endl;
+    fileOut << "    </image>" << Qt::endl;
+}
+
+void Mesh::writeMaterialsDAE(QTextStream &fileOut){
+    std::vector<int> chosenLOD;
+    if (elementArray.lodInfo.targetIndecies.size() <= file->parent->ListLevels->currentIndex()) {
+        chosenLOD = {0,static_cast<int>(elementArray.elementArray.size()-1)};
+    } else {
+        chosenLOD = elementArray.lodInfo.targetIndecies[file->parent->ListLevels->currentText().toInt(nullptr, 10)-1];
+    }
+
+    QString meshName = file->fileWithoutExtension + "-" + name;
+
+    QString checkTexture;
+    for(int element = chosenLOD[0]; element <= chosenLOD[1]; element++){
+        checkTexture = elementArray.elementArray[element].surfaceProperties.textureName;
+    }
+    if(checkTexture != elementArray.elementArray[chosenLOD[0]].surfaceProperties.textureName){
+        qDebug() << Q_FUNC_INFO << "checktexture" << checkTexture << "element texture" << elementArray.elementArray[chosenLOD[0]].surfaceProperties.textureName;
+        //file->parent->messageError("Mesh " + name + " has different textures for element " + QString::number(chosenLOD[0]) + " and " + QString::number(chosenLOD[1]) + ". Let Trevor know.");
+        //return;
+    }
+    fileOut << "    <material id=\"" + checkTexture +"Texture-material\" name=\"" + checkTexture +"Texture\">" << Qt::endl;
+    fileOut << "      <instance_effect url=\"#" + checkTexture +"Texture-effect\"/>" << Qt::endl;
+    fileOut << "    </material>" << Qt::endl;
+}
+
+void Mesh::writeDataSTL(QTextStream &fileOut){
     std::vector<int> chosenLOD;
     int triangle[3];
     QVector3D tempVec;
@@ -357,5 +471,177 @@ void Mesh::writeData(QTextStream &fileOut){
                 fileOut << "  endfacet" << Qt::endl;
             }
         }
+    }
+}
+
+void Mesh::writeDataDAE(QTextStream &fileOut){
+    std::vector<int> chosenLOD;
+    if (elementArray.lodInfo.targetIndecies.size() <= file->parent->ListLevels->currentIndex()) {
+        chosenLOD = {0,static_cast<int>(elementArray.elementArray.size()-1)};
+    } else {
+        chosenLOD = elementArray.lodInfo.targetIndecies[file->parent->ListLevels->currentText().toInt(nullptr, 10)-1];
+    }
+    QString meshName = file->fileWithoutExtension + "-" + name;
+    int triangleCount = 0;
+    QString checkTexture;
+    for(int element = chosenLOD[0]; element <= chosenLOD[1]; element++){
+        triangleCount += elementArray.elementArray[element].meshFaceSet.indexArray.getDAETriangleCount();
+        checkTexture = elementArray.elementArray[element].surfaceProperties.textureName;
+    }
+    if(checkTexture != elementArray.elementArray[chosenLOD[0]].surfaceProperties.textureName){
+        qDebug() << Q_FUNC_INFO << "checktexture" << checkTexture << "element texture" << elementArray.elementArray[chosenLOD[0]].surfaceProperties.textureName;
+        //file->parent->messageError("Mesh " + name + " has different textures for element " + QString::number(chosenLOD[0]) + " and " + QString::number(chosenLOD[1]) + ". Let Trevor know.");
+        //return;
+    }
+
+
+    fileOut << "    <geometry id=\"" + meshName + "-mesh\" name=\"" + meshName + "\">" << Qt::endl;
+    fileOut << "      <mesh>" << Qt::endl;
+
+    fileOut << "        <source id=\"" + meshName + "-mesh-positions\">" << Qt::endl;
+    fileOut << "          <float_array id=\"" + meshName + "-mesh-positions-array\" count = \"" + QString::number(vertexSet.positionArray.positionList.size()*3) + "\">";
+    for(int position = 0; position < vertexSet.positionArray.positionList.size(); position++){
+        fileOut << QString::number(vertexSet.positionArray.positionList[position].x()) << " ";
+        fileOut << QString::number(vertexSet.positionArray.positionList[position].y()) << " ";
+        fileOut << QString::number(vertexSet.positionArray.positionList[position].z()) << " ";
+    }
+    fileOut << "</float_array>" << Qt::endl;
+    fileOut << "          <technique_common>" << Qt::endl;
+    fileOut << "            <accessor source=\"#"+ meshName +"-mesh-positions-array\" count=\"" + QString::number(vertexSet.positionArray.positionList.size()) + "\" stride=\"3\">" << Qt::endl;
+    fileOut << "              <param name=\"X\" type=\"float\"/>" << Qt::endl;
+    fileOut << "              <param name=\"Y\" type=\"float\"/>" << Qt::endl;
+    fileOut << "              <param name=\"Z\" type=\"float\"/>" << Qt::endl;
+    fileOut << "            </accessor>" << Qt::endl;
+    fileOut << "          </technique_common>" << Qt::endl;
+    fileOut << "        </source>" << Qt::endl;
+
+    fileOut << "        <source id=\"" + meshName + "-mesh-normals\">" << Qt::endl;
+    fileOut << "          <float_array id=\"" + meshName + "-mesh-normals-array\" count = \"" + QString::number(vertexSet.normalArray.positionList.size()*3) + "\">";
+    for(int position = 0; position < vertexSet.normalArray.positionList.size(); position++){
+        fileOut << QString::number(vertexSet.normalArray.positionList[position].x()) << " ";
+        fileOut << QString::number(vertexSet.normalArray.positionList[position].y()) << " ";
+        fileOut << QString::number(vertexSet.normalArray.positionList[position].z()) << " ";
+    }
+    fileOut << "</float_array>" << Qt::endl;
+    fileOut << "          <technique_common>" << Qt::endl;
+    fileOut << "            <accessor source=\"#"+ meshName +"-mesh-normals-array\" count=\"" + QString::number(vertexSet.normalArray.positionList.size()) + "\" stride=\"3\">" << Qt::endl;
+    fileOut << "              <param name=\"X\" type=\"float\"/>" << Qt::endl;
+    fileOut << "              <param name=\"Y\" type=\"float\"/>" << Qt::endl;
+    fileOut << "              <param name=\"Z\" type=\"float\"/>" << Qt::endl;
+    fileOut << "            </accessor>" << Qt::endl;
+    fileOut << "          </technique_common>" << Qt::endl;
+    fileOut << "        </source>" << Qt::endl;
+
+    fileOut << "        <source id=\"" + meshName + "-mesh-map-0\">" << Qt::endl;
+    fileOut << "          <float_array id=\"" + meshName + "-mesh-map-0-array\" count = \"" + QString::number(vertexSet.textureCoords.positionList.size()*2) + "\">";
+    for(int position = 0; position < vertexSet.textureCoords.positionList.size(); position++){
+        fileOut << QString::number(vertexSet.textureCoords.positionList[position].x()) << " ";
+        fileOut << QString::number(vertexSet.textureCoords.positionList[position].y()) << " ";
+    }
+    fileOut << "</float_array>" << Qt::endl;
+    fileOut << "          <technique_common>" << Qt::endl;
+    fileOut << "            <accessor source=\"#"+ meshName +"-mesh-map-0-array\" count=\"" + QString::number(vertexSet.textureCoords.positionList.size()) + "\" stride=\"2\">" << Qt::endl;
+    fileOut << "              <param name=\"U\" type=\"float\"/>" << Qt::endl;
+    fileOut << "              <param name=\"V\" type=\"float\"/>" << Qt::endl;
+    fileOut << "            </accessor>" << Qt::endl;
+    fileOut << "          </technique_common>" << Qt::endl;
+    fileOut << "        </source>" << Qt::endl;
+
+//    fileOut << "        <source id=\"" + meshName + "-mesh-colors\">" << Qt::endl;
+//    fileOut << "          <float_array id=\"" + meshName + "-mesh-colors-array\" count = \"" + QString::number(vertexSet.colorArray.positionList.size()*4) + "\">";
+//    for(int position = 0; position < vertexSet.colorArray.positionList.size(); position++){
+//        fileOut << QString::number(vertexSet.colorArray.positionList[position].x()) << " ";
+//        fileOut << QString::number(vertexSet.colorArray.positionList[position].y()) << " ";
+//        fileOut << QString::number(vertexSet.colorArray.positionList[position].z()) << " ";
+//        fileOut << QString::number(vertexSet.colorArray.positionList[position].w()) << " ";
+//    }
+//    fileOut << "</float_array>" << Qt::endl;
+//    fileOut << "          <technique_common>" << Qt::endl;
+//    fileOut << "            <accessor source=\"#"+ meshName +"-mesh-colors-array\" count=\"" + QString::number(vertexSet.colorArray.positionList.size()) + "\" stride=\"4\">" << Qt::endl;
+//    fileOut << "              <param name=\"R\" type=\"float\"/>" << Qt::endl;
+//    fileOut << "              <param name=\"G\" type=\"float\"/>" << Qt::endl;
+//    fileOut << "              <param name=\"B\" type=\"float\"/>" << Qt::endl;
+//    fileOut << "              <param name=\"A\" type=\"float\"/>" << Qt::endl;
+//    fileOut << "            </accessor>" << Qt::endl;
+//    fileOut << "          </technique_common>" << Qt::endl;
+//    fileOut << "        </source>" << Qt::endl;
+
+    fileOut << "        <vertices id=\"" + meshName + "-mesh-vertices\">" << Qt::endl;
+    fileOut << "          <input semantic=\"POSITION\" source=\"#"+ meshName +"-mesh-positions\"/>" << Qt::endl;
+    fileOut << "        </vertices>" << Qt::endl;
+    fileOut << "        <triangles material=\"" + checkTexture +"Texture-material\" count=\"" + QString::number(triangleCount) + "\">" << Qt::endl;
+    fileOut << "          <input semantic=\"VERTEX\" source=\"#"+ meshName +"-mesh-vertices\" offset=\"0\"/>" << Qt::endl;
+    fileOut << "          <input semantic=\"NORMAL\" source=\"#"+ meshName +"-mesh-normals\" offset=\"0\"/>" << Qt::endl;
+    //fileOut << "          <input semantic=\"COLOR\" source=\"#"+ meshName +"-mesh-texcoords\" offset=\"0\"/>" << Qt::endl; //not sure if this is even an option in DAE
+    fileOut << "          <input semantic=\"TEXCOORD\" source=\"#"+ meshName +"-mesh-map-0\" offset=\"0\" set=\"0\"/>" << Qt::endl;
+
+    fileOut << "          <p>";
+    for(int element = chosenLOD[0]; element <= chosenLOD[1]; element++){
+        for (int strip = 0; strip < elementArray.elementArray[element].meshFaceSet.indexArray.triangleStrips.size(); strip++){
+            for (int triangle = 0 ; triangle < elementArray.elementArray[element].meshFaceSet.indexArray.triangleStrips[strip].stripIndecies.size()-2; triangle++ ){
+                fileOut << QString::number(elementArray.elementArray[element].meshFaceSet.indexArray.triangleStrips[strip].stripIndecies[triangle]) << " ";
+                fileOut << QString::number(elementArray.elementArray[element].meshFaceSet.indexArray.triangleStrips[strip].stripIndecies[triangle+1]) << " ";
+                fileOut << QString::number(elementArray.elementArray[element].meshFaceSet.indexArray.triangleStrips[strip].stripIndecies[triangle+2]) << " ";
+            }
+        }
+    }
+    fileOut << "</p>" << Qt::endl;
+    fileOut << "        </triangles>" << Qt::endl;
+    fileOut << "      </mesh>" << Qt::endl;
+    fileOut << "    </geometry>" << Qt::endl;
+}
+
+void Mesh::writeNodesDAE(QTextStream &fileOut){
+    std::vector<int> chosenLOD;
+    if (elementArray.lodInfo.targetIndecies.size() <= file->parent->ListLevels->currentIndex()) {
+        chosenLOD = {0,static_cast<int>(elementArray.elementArray.size()-1)};
+    } else {
+        chosenLOD = elementArray.lodInfo.targetIndecies[file->parent->ListLevels->currentText().toInt(nullptr, 10)-1];
+    }
+
+    QString meshName = file->fileWithoutExtension + "-" + name;
+
+    QString checkTexture;
+    for(int element = chosenLOD[0]; element <= chosenLOD[1]; element++){
+        checkTexture = elementArray.elementArray[element].surfaceProperties.textureName;
+    }
+    if(checkTexture != elementArray.elementArray[chosenLOD[0]].surfaceProperties.textureName){
+        qDebug() << Q_FUNC_INFO << "checktexture" << checkTexture << "element texture" << elementArray.elementArray[chosenLOD[0]].surfaceProperties.textureName;
+        //file->parent->messageError("Mesh " + name + " has different textures for element " + QString::number(chosenLOD[0]) + " and " + QString::number(chosenLOD[1]) + ". Let Trevor know.");
+        //return;
+    }
+
+    fileOut << "      <node id=\"" + meshName + "\" name=\"" + meshName + "\" type=\"NODE\">" << Qt::endl;
+    fileOut << "        <matrix sid=\"transform\">1 0 0 0 0 1 0 0 0 0 1 0 0 0 0 1</matrix>" << Qt::endl;
+    fileOut << "        <instance_geometry url=\"#" + meshName + "-mesh\" name=\"" + meshName + "\">" << Qt::endl;
+    fileOut << "          <bind_material>" << Qt::endl;
+    fileOut << "            <technique_common>" << Qt::endl;
+    fileOut << "              <instance_material symbol=\"" + checkTexture +"Texture-material\" target=\"#" + checkTexture +"Texture-material\">" << Qt::endl;
+    fileOut << "                <bind_vertex_input semantic=\"" + meshName + "-mesh-texcoords\" input_semantic=\"TEXCOORD\" input_set=\"0\"/>" << Qt::endl;
+    fileOut << "              </instance_material>" << Qt::endl;
+    fileOut << "            </technique_common>" << Qt::endl;
+    fileOut << "          </bind_material>" << Qt::endl;
+    fileOut << "        </instance_geometry>" << Qt::endl;
+    fileOut << "      </node>" << Qt::endl;
+}
+
+int IndexArray::getDAETriangleCount(){
+    int triangleCount = 0;
+    for(int strip = 0; strip < triangleStrips.size(); strip++){
+        triangleCount += triangleStrips[strip].stripIndecies.size();
+    }
+    return triangleCount;
+    //return triangleStrips.size();
+}
+
+void Mesh::applyKeyframe(QVector3D keyOffset){
+    for(int position = 0; position < vertexSet.positionArray.positionList.size(); position++){
+        vertexSet.positionArray.positionList[position] += keyOffset;
+    }
+}
+
+void Mesh::applyKeyframe(QQuaternion keyRotation){
+    for(int position = 0; position < vertexSet.positionArray.positionList.size(); position++){
+        vertexSet.positionArray.positionList[position] = keyRotation.rotatedVector(vertexSet.positionArray.positionList[position]);
     }
 }

--- a/Mesh.h
+++ b/Mesh.h
@@ -9,7 +9,7 @@ public:
     int levels;
     std::vector<std::vector<int>> targetIndecies;
     std::vector<float> levelDistance;
-    VBIN *file;
+    FileData *fileData;
 
     void populateLevels();
     void clear();
@@ -20,11 +20,13 @@ public:
     int arrayID;
     int arrayLength;
     long fileLocation;
+    int triangleCount;
     std::vector<TriangleStrip> triangleStrips;
     std::vector<int> indexList;
-    VBIN *file;
+    FileData *fileData;
 
     void populateTriangleStrips();
+    int getDAETriangleCount();
 };
 
 class MeshFaceSet{
@@ -42,7 +44,7 @@ public:
   long fileLocation;
   QString meshName;
   std::vector<QVector3D> positionList;
-  VBIN *file;
+  FileData *fileData;
 
   void Transform();
   //void getIndexArrays();
@@ -59,7 +61,7 @@ public:
     NormalArray normalArray;
     ColorArray colorArray;
     TextureCoords textureCoords;
-    VBIN *file;
+    FileData *fileData;
 
     void getArrayLocations();
 };
@@ -99,7 +101,7 @@ public:
 
 class SurfaceProperties{
 public:
-    QString name;
+    QString textureName;
     int materialRelated; //recorded values are 4 and 5, with the lowest bit indicating a difference in the material section
     int unknownProperty2;
     Material material;
@@ -134,11 +136,18 @@ public:
     int elementCount;
 
     void clear();
+    void applyKeyframe(QVector3D keyOffset);
+    void applyKeyframe(QQuaternion keyRotation);
     void readData(long meshLocation);
     int readMesh();
     //void modifyPosArrays(Modifications mods);
     void getModifications();
-    void writeData(QTextStream &fileOut);
+    void writeDataSTL(QTextStream &fileOut);
+    void writeDataDAE(QTextStream &fileOut);
+    void writeNodesDAE(QTextStream &FileOut);
+    void writeEffectsDAE(QTextStream &FileOut);
+    void writeImagesDAE(QTextStream &FileOut);
+    void writeMaterialsDAE(QTextStream &FileOut);
     void modify(std::vector<Modifications> addedMods);
     const void operator=(Mesh input);
 };

--- a/ToneLibrary.cpp
+++ b/ToneLibrary.cpp
@@ -14,6 +14,10 @@ void VACFile::tempRead(){
 }
 
 void VACFile::tempWrite(){
+    if(this->noteList.empty()){
+       parent->messageError("No audio files available to export. Please load an audio file.");
+       return;
+    }
     QString fileOut = QFileDialog::getSaveFileName(parent, parent->tr("Select Output VAC"), QDir::currentPath() + "/VAC/", parent->tr("Tone Files (*.vac)"));
     QFile vacOut(fileOut);
     QFile file(fileOut);

--- a/VBINConverter.pro
+++ b/VBINConverter.pro
@@ -1,0 +1,49 @@
+QT       += core gui
+qt       += quick quick3d
+
+greaterThan(QT_MAJOR_VERSION, 4): QT += widgets
+
+CONFIG += c++11
+
+# You can make your code fail to compile if it uses deprecated APIs.
+# In order to do so, uncomment the following line.
+#DEFINES += QT_DISABLE_DEPRECATED_BEFORE=0x060000    # disables all the APIs deprecated before Qt 6.0.0
+
+SOURCES += \
+    Antioch2.cpp \
+    BMPandPNGConversion.cpp \
+    BinChanger.cpp \
+    Database.cpp \
+    DatabaseItems.cpp \
+    ITFtoBMP.cpp \
+    LevelGeo.cpp \
+    Mesh.cpp \
+    ToneLibrary.cpp \
+    VBINtoSTL.cpp \
+    main.cpp \
+    mainwindow.cpp \
+    openfile.cpp \
+    stolenunswizzler.cpp
+
+HEADERS += \
+    Antioch2.h \
+    BinChanger.h \
+    Database.h \
+    DistanceCalculations.h \
+    LevelGeo.h \
+    Mesh.h \
+    ToneLibraries.h \
+    itf.h \
+    mainwindow.h \
+    vbin.h
+
+FORMS += \
+    mainwindow.ui
+
+# Default rules for deployment.
+qnx: target.path = /tmp/$${TARGET}/bin
+else: unix:!android: target.path = /opt/$${TARGET}/bin
+!isEmpty(target.path): INSTALLS += target
+
+DISTFILES +=
+

--- a/itf.h
+++ b/itf.h
@@ -55,6 +55,7 @@ public:
     void saveITFPalette();
     void unswizzle_8bit();
     void unswizzle_4bit();
+    void unswizzle_GPT();
     void unswizzle();
     void swizzle();
     void convertBMPtoPNG(QString bmpPath);

--- a/mainwindow.h
+++ b/mainwindow.h
@@ -37,6 +37,7 @@
 #include "LevelGeo.h"
 #include "Database.h"
 #include "ToneLibraries.h"
+#include "DistanceCalculations.h"
 
 
 QT_BEGIN_NAMESPACE
@@ -66,6 +67,7 @@ public:
     int hSize = 1200;
     int vSize = 768;
     int mode = 0;
+    float version = 5.4;
 
     QString fileMode;
 
@@ -73,6 +75,7 @@ public:
 
     QLabel *LabelMode;
     QLabel *LabelName;
+    QLabel *ClosestWarpgate;
 
     QPushButton *ButtonVBINtoSTL;
     QPushButton *ButtonOpenVBIN;
@@ -87,11 +90,17 @@ public:
     QPushButton *ButtonEditDB;
     QPushButton *ButtonRemoveItem;
     QPushButton *ButtonRemoveClass;
+    QPushButton *ButtonCalculate;
+    QLineEdit *CalculateXValue;
+    QLineEdit *CalculateYValue;
+    QLineEdit *CalculateZValue;
     QLineEdit *DBNewValue;
     QRadioButton *radioSingle;
     QRadioButton *radioMultiple;
     QComboBox *ListLevels;
     QComboBox *ListFiles;
+    QComboBox *ListAnimation;
+    QComboBox *ListFrame;
     QPushButton *ButtonSaveITF;
     FileData fileData;
     QTableWidget *PaletteTable;
@@ -117,11 +126,14 @@ public:
     void createTable(int rows, int columns);
     void createLevelList(int levels);
     void createFileList();
+    void createAnimationList(AnimationSourceSet animations);
+    void createFrameList(int frames);
     void createMultiRadios();
     void deleteMultiRadios();
     void createDBButtons();
     void levelSelectChange();
     void fileSelectChange();
+    void animationSelectChange();
     void clearWindow();
     void changeName(QString newName);
 
@@ -135,9 +147,12 @@ private:
     void saveITFFile();
     void saveBMPFile();
     int changeMode(int newMode);
+    void openWarpgateCalculator();
+    void calculateWarpgateDistance();
 
 public slots:
     void convertVBINToSTL();
+    void convertVBINToDAE();
     //void convertITFToBMP();
     //void convertBMPtoPNG(QString bmpPath);
     void openVBIN();

--- a/openfile.cpp
+++ b/openfile.cpp
@@ -17,6 +17,7 @@ void ProgWindow::openVBIN(){
         inputFile.open(QIODevice::ReadOnly);
         QFileInfo fileInfo(inputFile);
         vbinFile.fileName = fileInfo.fileName();
+        vbinFile.fileWithoutExtension = vbinFile.fileName.left(vbinFile.fileName.indexOf("."));
 //        fileData.dataBytes.clear();
 
 //        QFile inputFile(fileIn);
@@ -33,6 +34,7 @@ void ProgWindow::openVBIN(){
         createLevelList(vbinFile.highestLOD);
         createFileList();
         createMultiRadios();
+        //createAnimationList(vbinFile.animationSet);
     } else {
         messageError("There was an error opening the file.");
     }

--- a/vbin.h
+++ b/vbin.h
@@ -6,6 +6,8 @@
 #include <QByteArrayMatcher>
 #include <QTransform>
 
+#include "Antioch2.h"
+#include "BinChanger.h"
 
 class ProgWindow;
 
@@ -32,7 +34,7 @@ public:
     int type;
     QVector3D location;
     float radius;
-    VBIN *file;
+    FileData *fileData;
 
     void populateData();
     const void operator=(BoundingVolume input);
@@ -52,7 +54,7 @@ public:
   int arrayID;
   long arrayLength;
   QString meshName;
-  VBIN *file;
+  FileData *fileData;
   std::vector<QVector3D> positionList;
 };
 
@@ -61,7 +63,7 @@ public:
   int arrayID;
   long arrayLength;
   QString meshName;
-  VBIN *file;
+  FileData *fileData;
   std::vector<QVector4D> positionList;
 };
 
@@ -70,7 +72,7 @@ public:
   int arrayID;
   long arrayLength;
   QString meshName;
-  VBIN *file;
+  FileData *fileData;
   std::vector<QVector2D> positionList;
 };
 
@@ -87,6 +89,7 @@ public:
 class FileSection{
 public:
     VBIN *file;
+    FileData *fileData;
     FileSection *parent;
     long fileLocation;
     QString name;
@@ -103,15 +106,26 @@ public:
     void readData(long sceneLocation);
     void getSceneNodeTree(long searchStart, long searchEnd, int depth);
     void readNode();
+    void sendKeyframe(QVector3D keyOffset, QString channelName);
+    void sendKeyframe(QQuaternion keyRotation, QString channelName);
     void readModifications();
     //void getModifications();
     void modifyPosArrays(std::vector<Modifications> addedMods);
     void printInfo(int depth); // for debugging
     const void operator=(FileSection input);
-    void writeSectionList(QTextStream &file);
-    void writeSectionList(QString path);
+    void writeSectionListSTL(QTextStream &file);
+    void writeSectionListSTL(QString path);
+    void writeSectionListDAE(QTextStream &file);
+    void writeSectionListDAE(QString path);
+    void writeSceneListDAE(QTextStream &file);
+    void writeSceneListDAE(QString path);
+    void writeEffectListDAE(QTextStream &file);
+    void writeEffectListDAE(QString path);
+    void writeImageListDAE(QTextStream &file);
+    void writeImageListDAE(QString path);
+    void writeMaterialListDAE(QTextStream &file);
+    void writeMaterialListDAE(QString path);
     void modify(std::vector<Modifications> addedMods);
-    void writeData(QTextStream &fileOut);
     // void modifyPosArrays(); //this might go somewhere else, just
     // commenting out for now
     void clear();
@@ -121,7 +135,9 @@ class SceneNode : public FileSection{
 public:
     void readData(long sceneLocation);
     void modify(std::vector<Modifications> addedMods);
-    void writeData(QTextStream &fileOut);
+    void writeDataSTL(QTextStream &fileOut);
+    void writeDataDAE(QTextStream &fileOut);
+    void writeSceneListDAE(QTextStream &FileOut);
     //void getModifications(); //inherited version should be workable
     //void modifyPosArrays();
     void clear();
@@ -133,7 +149,10 @@ public:
     const QStringList sectionNames = {"~SceneNode", "~PositionArray", "~LODinfo", "~BoundingVolume", "~VertexSet"};
     QString filePath;
     ProgWindow *parent;
+    FileData *fileData;
     QString fileName;
+    QString fileWithoutExtension;
+    AnimationSourceSet animationSet;
     int highestLOD;
     long currentLocation;
     FileSection base;
@@ -141,7 +160,9 @@ public:
     std::vector<int> getIndexArrays(int posCount, int chosenLOD, int location);
     void makeTriangles(std::vector<int> indArrays, int whichArray, int location, QTextStream *stream);
     int readData();
-    void outputData();
+    void applyKeyframe();
+    void outputDataSTL();
+    void outputDataDAE();
 private:
     //void modifyPosArrays();
     void outputPositionList(int location);


### PR DESCRIPTION
Added ability to export files in .DAE format, including normals and texture data.

Corrected swizzling algorithm to properly decode .ITF texture files.

Added a distance calculator for Amazon warpgates. This needs significant work.

Added the beginning of animation reading. This still needs significant research in order to actually apply the animations.